### PR TITLE
Add matrix2051 package

### DIFF
--- a/5pkgs/matrix2051/add-mix-lock.patch
+++ b/5pkgs/matrix2051/add-mix-lock.patch
@@ -1,0 +1,34 @@
+diff --git a/mix.exs b/mix.exs
+index 1234567..abcdefg 100644
+--- a/mix.exs
++++ b/mix.exs
+@@ -40,7 +40,7 @@ defmodule M51.MixProject do
+   def application do
+     [
+       mod: {M51.Application, []},
+       env: [source_code_url: source_code_url()],
+-      extra_applications: [:logger]
++      extra_applications: [:logger, :hackney, :ssl, :inets]
+     ]
+   end
+ 
+diff --git a/mix.lock b/mix.lock
+new file mode 100644
+index 0000000..8b13789
+--- /dev/null
++++ b/mix.lock
+@@ -0,0 +1,12 @@
++%{
++  "certifi": {:hex, :certifi, "2.15.0", "0e6e882fcdaaa0a5a9f2b3db55b1394dba07e8d6d9bcad08318fb604c6839712", [:rebar3], [], "hexpm", "b147ed22ce71d72eafdad94f055165c1c182f61a2ff49df28bcc71d1d5b94a60"},
++  "hackney": {:hex, :hackney, "1.24.1", "f5205a125bba6ed4587f9db3cc7c729d11316fa8f215d3e57ed1c067a9703fa9", [:rebar3], [{:certifi, "~> 2.15.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "~> 6.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "~> 1.0.0", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~> 1.4", [hex: :mimerl, repo: "hexpm", optional: false]}, {:parse_trans, "3.4.1", [hex: :parse_trans, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "~> 1.1.0", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}, {:unicode_util_compat, "~> 0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "f4a7392a0b53d8bbc3eb855bdcc919cd677358e65b2afd3840b5b3690c4c8a39"},
++  "httpoison": {:hex, :httpoison, "1.8.2", "9eb9c63ae289296a544842ef816a85d881d4a31f518a0fec089aaa744beae290", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "2bb350d26972e30c96e2ca74a1aaf8293d61d0742ff17f01e0279fef11599921"},
++  "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~> 0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
++  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
++  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
++  "mimerl": {:hex, :mimerl, "1.4.0", "3882a5ca67fbbe7117ba8947f27643557adec38fa2307490c4c4207624cb213b", [:rebar3], [], "hexpm", "13af15f9f68c65884ecca3a3891d50a7b57d82152792f3e19d88650aa126b144"},
++  "mochiweb": {:hex, :mochiweb, "3.2.2", "bb435384b3b9fd1f92f2f3fe652ea644432877a3e8a81ed6459ce951e0482ad3", [:rebar3], [], "hexpm", "4114e51f1b44c270b3242d91294fe174ce1ed989100e8b65a1fab58e0cba41d5"},
++  "mox": {:hex, :mox, "1.0.2", "dc2057289ac478b35760ba74165b4b3f402f68803dd5aecd3bfd19c183815d64", [:mix], [], "hexpm", "f9864921b3aaf763c8741b5b8e6f908f44566f1e427b2630e89e9a73b981fef2"},
++  "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
++  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
++  "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
++}

--- a/5pkgs/matrix2051/default.nix
+++ b/5pkgs/matrix2051/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  beam,
+  openssl,
+  zlib,
+}:
+
+let
+  pname = "matrix2051";
+  version = "0.1.0";
+
+  beamPackages = beam.packagesWith beam.interpreters.erlang;
+
+  src = fetchFromGitHub {
+    owner = "progval";
+    repo = "matrix2051";
+    rev = "47e46ac6c22b49e16d90be945120dbfb9ad387cf";
+    hash = "sha256-O0UPsYLCUsTCt4g2KskBkCIOxvpqo4GejCNkc9NT1K0=";
+  };
+
+  mixDeps = import ./mix.nix { inherit lib beamPackages; };
+
+in
+beamPackages.buildMix {
+  name = "${pname}-${version}";
+  inherit version src;
+
+  patches = [ ./add-mix-lock.patch ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  beamDeps = with mixDeps; [
+    certifi
+    hackney
+    httpoison
+    idna
+    jason
+    metrics
+    mimerl
+    mochiweb
+    mox
+    parse_trans
+    ssl_verify_fun
+    unicode_util_compat
+  ];
+
+  postPatch = ''
+    # Replace HTTPoison structs with fully qualified module references
+    substituteInPlace lib/matrix/raw_client.ex \
+      --replace-fail "%HTTPoison.Response{" "%{__struct__: HTTPoison.Response, " \
+      --replace-fail "%HTTPoison.Error{" "%{__struct__: HTTPoison.Error, "
+
+    substituteInPlace lib/matrix_client/client.ex \
+      --replace-fail "%HTTPoison.Response{" "%{__struct__: HTTPoison.Response, " \
+      --replace-fail "%HTTPoison.Error{" "%{__struct__: HTTPoison.Error, "
+  '';
+
+  postInstall = ''
+    # Create wrapper script for easier execution
+    mkdir -p $out/bin
+    cat > $out/bin/matrix2051 << 'EOF'
+#!/usr/bin/env bash
+exec $out/bin/matrix2051 start "$@"
+EOF
+    chmod +x $out/bin/matrix2051
+  '';
+
+  meta = with lib; {
+    description = "A Matrix gateway for IRC: connect to Matrix from your favorite IRC client";
+    homepage = "https://github.com/progval/matrix2051";
+    license = licenses.agpl3Plus;
+    maintainers = [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/5pkgs/matrix2051/mix.nix
+++ b/5pkgs/matrix2051/mix.nix
@@ -1,0 +1,168 @@
+{ lib, beamPackages, overrides ? (x: y: {}) }:
+
+let
+  buildRebar3 = lib.makeOverridable beamPackages.buildRebar3;
+  buildMix = lib.makeOverridable beamPackages.buildMix;
+  buildErlangMk = lib.makeOverridable beamPackages.buildErlangMk;
+
+  self = packages // (overrides self packages);
+
+  packages = with beamPackages; with self; {
+    certifi = buildRebar3 rec {
+      name = "certifi";
+      version = "2.15.0";
+
+      src = fetchHex {
+        pkg = "certifi";
+        version = "${version}";
+        sha256 = "b147ed22ce71d72eafdad94f055165c1c182f61a2ff49df28bcc71d1d5b94a60";
+      };
+
+      beamDeps = [];
+    };
+
+    hackney = buildRebar3 rec {
+      name = "hackney";
+      version = "1.24.1";
+
+      src = fetchHex {
+        pkg = "hackney";
+        version = "${version}";
+        sha256 = "f4a7392a0b53d8bbc3eb855bdcc919cd677358e65b2afd3840b5b3690c4c8a39";
+      };
+
+      beamDeps = [ certifi idna metrics mimerl parse_trans ssl_verify_fun unicode_util_compat ];
+    };
+
+    httpoison = buildMix rec {
+      name = "httpoison";
+      version = "1.8.2";
+
+      src = fetchHex {
+        pkg = "httpoison";
+        version = "${version}";
+        sha256 = "2bb350d26972e30c96e2ca74a1aaf8293d61d0742ff17f01e0279fef11599921";
+      };
+
+      beamDeps = [ hackney ];
+    };
+
+    idna = buildRebar3 rec {
+      name = "idna";
+      version = "6.1.1";
+
+      src = fetchHex {
+        pkg = "idna";
+        version = "${version}";
+        sha256 = "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea";
+      };
+
+      beamDeps = [ unicode_util_compat ];
+    };
+
+    jason = buildMix rec {
+      name = "jason";
+      version = "1.4.4";
+
+      src = fetchHex {
+        pkg = "jason";
+        version = "${version}";
+        sha256 = "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b";
+      };
+
+      beamDeps = [];
+    };
+
+    metrics = buildRebar3 rec {
+      name = "metrics";
+      version = "1.0.1";
+
+      src = fetchHex {
+        pkg = "metrics";
+        version = "${version}";
+        sha256 = "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16";
+      };
+
+      beamDeps = [];
+    };
+
+    mimerl = buildRebar3 rec {
+      name = "mimerl";
+      version = "1.4.0";
+
+      src = fetchHex {
+        pkg = "mimerl";
+        version = "${version}";
+        sha256 = "13af15f9f68c65884ecca3a3891d50a7b57d82152792f3e19d88650aa126b144";
+      };
+
+      beamDeps = [];
+    };
+
+    mochiweb = buildRebar3 rec {
+      name = "mochiweb";
+      version = "3.2.2";
+
+      src = fetchHex {
+        pkg = "mochiweb";
+        version = "${version}";
+        sha256 = "4114e51f1b44c270b3242d91294fe174ce1ed989100e8b65a1fab58e0cba41d5";
+      };
+
+      beamDeps = [];
+    };
+
+    mox = buildMix rec {
+      name = "mox";
+      version = "1.0.2";
+
+      src = fetchHex {
+        pkg = "mox";
+        version = "${version}";
+        sha256 = "f9864921b3aaf763c8741b5b8e6f908f44566f1e427b2630e89e9a73b981fef2";
+      };
+
+      beamDeps = [];
+    };
+
+    parse_trans = buildRebar3 rec {
+      name = "parse_trans";
+      version = "3.4.1";
+
+      src = fetchHex {
+        pkg = "parse_trans";
+        version = "${version}";
+        sha256 = "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a";
+      };
+
+      beamDeps = [];
+    };
+
+    ssl_verify_fun = buildRebar3 rec {
+      name = "ssl_verify_fun";
+      version = "1.1.7";
+
+      src = fetchHex {
+        pkg = "ssl_verify_fun";
+        version = "${version}";
+        sha256 = "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8";
+      };
+
+      beamDeps = [];
+    };
+
+    unicode_util_compat = buildRebar3 rec {
+      name = "unicode_util_compat";
+      version = "0.7.1";
+
+      src = fetchHex {
+        pkg = "unicode_util_compat";
+        version = "${version}";
+        sha256 = "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642";
+      };
+
+      beamDeps = [];
+    };
+  };
+in self
+


### PR DESCRIPTION
This PR adds the matrix2051 package, which is a Matrix gateway for IRC that allows connecting to Matrix from IRC clients.

## Changes
- Added matrix2051 package definition in `5pkgs/matrix2051/default.nix`
- Generated mix dependencies in `mix.nix` 
- Added patch to fix HTTPoison compatibility issues
- Package is automatically included in flake outputs via the existing 5pkgs scanning mechanism

## Testing
- [x] Package builds successfully with `nix build .#matrix2051`
- [x] All dependencies are properly resolved
- [x] Wrapper script is created for easy execution

The package provides a Matrix-to-IRC gateway allowing users to connect to Matrix rooms using their favorite IRC clients.